### PR TITLE
Do not filter test resource

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -386,7 +386,7 @@
 		<testResources>
 			<testResource>
 				<directory>src/test/resources</directory>
-				<filtering>true</filtering>
+				<filtering>false</filtering>
 			</testResource>
 		</testResources>
 


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
The test resource has a PDF file. It won't make sense to do the filter PDF and it will cause an issue with `maven-resources-plugin` version `3.3.1`.

Also, we don't seem to have any macros such as `${...}` or `@...@` in the test resource so it is safe to disable the filtering.

See https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html